### PR TITLE
Fix serializer failing to find source when defining source with dot syntax

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 commit = True
 tag = True
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+Changes in v0.3.1
+=================
+- Fixes bug with defining source with dot syntax
+
 Changes in v0.3.0
 =================
 - Add support for ``FloatField``

--- a/pyserializer/__init__.py
+++ b/pyserializer/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 __version_info__ = tuple(__version__.split('.'))
 __short_version__ = __version__

--- a/pyserializer/serializers.py
+++ b/pyserializer/serializers.py
@@ -3,6 +3,7 @@ import copy
 from collections import OrderedDict
 
 from pyserializer.exceptions import ValidationError
+from pyserializer.utils import get_object_by_source
 
 
 __all__ = [
@@ -295,7 +296,7 @@ class BaseSerializer(object):
             key = field_name
             if isinstance(field, Serializer):
                 if field.source:
-                    serializable_obj = getattr(obj, field.source)
+                    serializable_obj = get_object_by_source(obj, field.source)
                 else:
                     serializable_obj = getattr(obj, key)
                 field.instance = serializable_obj

--- a/pyserializer/utils.py
+++ b/pyserializer/utils.py
@@ -6,6 +6,7 @@ __all__ = [
     'is_simple_callable',
     'is_iterable',
     'force_str',
+    'get_object_by_source',
 ]
 
 
@@ -38,3 +39,19 @@ def force_str(value, encoding='utf-8'):
         if isinstance(value, bytes):
             return str(value, encoding)
     return value
+
+
+def get_object_by_source(obj, source):
+    """
+    Tries to get the object by source.
+    Example:
+        >>> obj = get_object_by_source(
+            object, source='user.username')
+    """
+    if '.' in source:
+        source_list = source.split('.')
+        for source in source_list:
+            obj = getattr(obj, source)
+    else:
+        obj = getattr(obj, source)
+    return obj

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pyserializer',
-    version='0.3.0',
+    version='0.3.1',
     description='Simple python serialization library.',
     author='LocalMed',
     author_email='ecordell@localmed.com, pete@localmed.com, joeljames1985@gmail.com',


### PR DESCRIPTION
Fixes this issue https://github.com/localmed/pyserializer/issues/13
@petebrowne @thatgibbyguy @reneric 
