### PR TITLE
Add support for custom error message

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.0
+current_version = 0.8.0
 commit = True
 tag = True
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+Changes in v0.8.0
+=================
+- Add support for custom error message when declaring a field
+
 Changes in v0.7.0
 =================
 - Add support for ``EmailField``

--- a/docs/custom_error_messages.rst
+++ b/docs/custom_error_messages.rst
@@ -1,0 +1,16 @@
+=====================
+Custom Error Messages
+=====================
+A quick example on how to set custom error messages on fields.
+
+
+Custom Error Messages on Fields
+===============================
+Validation error messages for fields can be configured by passing in ``error_messages`` argument to the Field's constructor::
+
+    from pyserializer import fields
+
+    class UserDeserializer(Serializer):
+        dob = fields.DateField(
+            error_messages={'invalid': 'Please provide a valid date of birth for user.'}
+        )

--- a/docs/custom_fields.rst
+++ b/docs/custom_fields.rst
@@ -1,0 +1,38 @@
+=============
+Custom Fields
+=============
+A quick example on how to create custom fields.
+
+
+Create Custom Fields
+====================
+
+Lets assume we want to create a custom UUID field. Creating a field only requires you to define the ``to_native`` and ``to_python`` on the field class. All custom fields should inherit from ``Field`` class. The class variables ``type_name`` and ``type_label`` are for meta information. Exaple UUID field::
+
+    from pyserializer.fields import Field
+
+    class UUIDField(Field):
+        type_name = 'UUIDField'
+        type_label = 'string'
+        default_error_messages = {
+            'invalid': ('The value received for UUIDField (%s)'
+                        ' is not a valid UUID format.')
+        }
+        default_validators = [validators.UUIDValidator()] # All the validations should be handeled by the validator.
+
+        def __init__(self,
+                     *args,
+                     **kwargs):
+            super(UUIDField, self).__init__(*args, **kwargs)
+
+        def to_native(self, value):
+            if value is None:
+                return value
+            return six.text_type(value)
+
+        def to_python(self, value):
+            if value in constants.EMPTY_VALUES:
+                return None
+            if isinstance(value, uuid.UUID):
+                return value
+            return uuid.UUID(str(value))

--- a/docs/custom_validators.rst
+++ b/docs/custom_validators.rst
@@ -1,41 +1,7 @@
-======
-Custom
-======
-A quick example on how to create custom Fields and vaildators.
-
-
-Create Custom Fields
-====================
-
-Lets assume we want to create a custom UUID field. Creating a field only requires you to define the ``to_native`` and ``to_python`` on the field class. All custom fields should inherit from ``Field`` class. The class variables ``type_name`` and ``type_label`` are for meta information. Exaple UUID field::
-
-    from pyserializer.fields import Field
-
-    class UUIDField(Field):
-        type_name = 'UUIDField'
-        type_label = 'string'
-        default_error_messages = {
-            'invalid': ('The value received for UUIDField (%s)'
-                        ' is not a valid UUID format.')
-        }
-        default_validators = [validators.UUIDValidator()] # All the validations should be handeled by the validator.
-
-        def __init__(self,
-                     *args,
-                     **kwargs):
-            super(UUIDField, self).__init__(*args, **kwargs)
-
-        def to_native(self, value):
-            if value is None:
-                return value
-            return six.text_type(value)
-
-        def to_python(self, value):
-            if value in constants.EMPTY_VALUES:
-                return None
-            if isinstance(value, uuid.UUID):
-                return value
-            return uuid.UUID(str(value))
+=================
+Custom Validators
+=================
+A quick example on how to create custom validators.
 
 
 Create Custom Validators

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,8 +39,14 @@ Also, you can get the source from `GitHub <https://github.com/localmed/pyseriali
 :doc:`fields`
   A list of currently supported fields.
 
-:doc:`custom`
-  A quick example on how you can create custom fields and validators.
+:doc:`custom_error_messages`
+  A quick example on how to set custom error messages on fields.
+
+:doc:`custom_fields`
+  A quick example on how you can create custom fields.
+
+:doc:`custom_validators`
+  A quick example on how you can create custom validators.
 
 :doc:`apireference`
   The complete API documentation.
@@ -123,8 +129,10 @@ The project is licensed under the MIT license.
     deserialization
     validation
     fields
+    custom_error_messages
+    custom_fields
+    custom_validators
     apireference
-    custom
     changelog
 
 Indices and tables

--- a/pyserializer/__init__.py
+++ b/pyserializer/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.7.0'
+__version__ = '0.8.0'
 __version_info__ = tuple(__version__.split('.'))
 __short_version__ = __version__

--- a/pyserializer/fields.py
+++ b/pyserializer/fields.py
@@ -68,8 +68,14 @@ class Field(object):
         self.validators = self.default_validators + (validators or [])
         self.error_dict = OrderedDict()
         if error_messages:
-            self.error_dict['type_name'] = kwargs.pop('type_name', self.type_name)
-            self.error_dict['type_label'] = kwargs.pop('type_label', self.type_label)
+            self.error_dict['type_name'] = kwargs.pop(
+                'type_name',
+                self.type_name
+            )
+            self.error_dict['type_label'] = kwargs.pop(
+                'type_label',
+                self.type_label
+            )
             self.error_dict['message'] = error_messages['invalid']
 
         self.empty = kwargs.pop('empty', '')

--- a/pyserializer/fields.py
+++ b/pyserializer/fields.py
@@ -66,19 +66,25 @@ class Field(object):
         self.label = label
         self.help_text = help_text
         self.validators = self.default_validators + (validators or [])
+        self.type_name = kwargs.pop(
+            'type_name',
+            self.type_name
+        )
+        self.type_label = kwargs.pop(
+            'type_label',
+            self.type_label
+        )
         self.error_dict = OrderedDict()
         if error_messages:
-            self.error_dict['type_name'] = kwargs.pop(
-                'type_name',
-                self.type_name
-            )
-            self.error_dict['type_label'] = kwargs.pop(
-                'type_label',
-                self.type_label
-            )
-            self.error_dict['message'] = error_messages['invalid']
+            self._create_error_dict(error_messages)
 
         self.empty = kwargs.pop('empty', '')
+
+    def _create_error_dict(self, error_messages):
+        self.error_dict['type_name'] = self.type_name
+        self.error_dict['type_label'] = self.type_label
+        for key, value in six.iteritems(error_messages):
+            self.error_dict[key] = value
 
     def field_to_native(self,
                         obj,

--- a/pyserializer/fields.py
+++ b/pyserializer/fields.py
@@ -3,6 +3,7 @@ from datetime import datetime, date
 import warnings
 import uuid
 import decimal
+from collections import OrderedDict
 
 from pyserializer.utils import (
     is_simple_callable,
@@ -48,6 +49,7 @@ class Field(object):
                  label=None,
                  help_text=None,
                  validators=None,
+                 error_messages=None,
                  *args,
                  **kwargs):
         """
@@ -58,11 +60,18 @@ class Field(object):
         :param validators: List of validators that should be ran when
             deserializing the field. This list will be appended along with
             the default_validators defined on each field.
+        :param error_messages: (dict) Custom error message on the field.
         """
         self.source = source
         self.label = label
         self.help_text = help_text
         self.validators = self.default_validators + (validators or [])
+        self.error_dict = OrderedDict()
+        if error_messages:
+            self.error_dict['type_name'] = kwargs.pop('type_name', self.type_name)
+            self.error_dict['type_label'] = kwargs.pop('type_label', self.type_label)
+            self.error_dict['message'] = error_messages['invalid']
+
         self.empty = kwargs.pop('empty', '')
 
     def field_to_native(self,

--- a/pyserializer/serializers.py
+++ b/pyserializer/serializers.py
@@ -148,10 +148,6 @@ class BaseSerializer(object):
                     field_name,
                     field
                 )
-                ## replace field error message with custom errror message
-                ## if the field has an error_messages set on it
-                ## and has an error while running the validators set n the field
-                ## _overwrite_field_error_message_with_default_field_error_message
 
 
     def invoke_validators_and_set_errors(self,
@@ -184,7 +180,7 @@ class BaseSerializer(object):
         then the filed error message will be overwritten by the custom field error message.
         """
         if self._errors.get(field_name) and field.error_dict:
-            self._errors[field_name] = field.error_dict
+            self._errors[field_name] = [field.error_dict]
 
     @property
     def object(self):

--- a/pyserializer/serializers.py
+++ b/pyserializer/serializers.py
@@ -130,7 +130,8 @@ class BaseSerializer(object):
 
     def perform_validation(self, fields, data):
         """
-        Runs the validators specified on the fields and sets the error messages.
+        Runs the validators specified on the fields
+        and sets the error messages.
         """
         for field_name, field in six.iteritems(fields):
             if isinstance(field, Serializer):
@@ -144,11 +145,10 @@ class BaseSerializer(object):
                     validators=field.validators,
                     value=data.get(field_name)
                 )
-                self._overwrite_field_error_message_with_custom_field_error_message(
+                self._overwrite_field_error_message_with_custom_field_error_message(  # flake8: noqa
                     field_name,
                     field
                 )
-
 
     def invoke_validators_and_set_errors(self,
                                          field_name,
@@ -173,7 +173,8 @@ class BaseSerializer(object):
     def _overwrite_field_error_message_with_custom_field_error_message(self,
             field_name, field):
         """
-        Overwrites the field error message(set by validators) with custom field error message.
+        Overwrites the field error message(set by validators)
+        with custom field error message.
 
         If the field has an `error_messages` property set on it
         and the field has encountered an error while running the validators;

--- a/pyserializer/serializers.py
+++ b/pyserializer/serializers.py
@@ -130,7 +130,7 @@ class BaseSerializer(object):
 
     def perform_validation(self, fields, data):
         """
-        Runs the validators specified on the fields.
+        Runs the validators specified on the fields and sets the error messages.
         """
         for field_name, field in six.iteritems(fields):
             if isinstance(field, Serializer):
@@ -139,16 +139,25 @@ class BaseSerializer(object):
                     data=data.get(field_name)
                 )
             else:
-                self.invoke_validators(
+                self.invoke_validators_and_set_errors(
                     field_name=field_name,
                     validators=field.validators,
                     value=data.get(field_name)
                 )
+                self._overwrite_field_error_message_with_custom_field_error_message(
+                    field_name,
+                    field
+                )
+                ## replace field error message with custom errror message
+                ## if the field has an error_messages set on it
+                ## and has an error while running the validators set n the field
+                ## _overwrite_field_error_message_with_default_field_error_message
 
-    def invoke_validators(self,
-                          field_name,
-                          validators,
-                          value):
+
+    def invoke_validators_and_set_errors(self,
+                                         field_name,
+                                         validators,
+                                         value):
         """
         Calls the validators on the fields.
         Catches the `ValidationError` raised and stores the
@@ -164,6 +173,18 @@ class BaseSerializer(object):
         # Delete the key from the dict, if no error is appended to the list
         if not self._errors[field_name]:
             del self._errors[field_name]
+
+    def _overwrite_field_error_message_with_custom_field_error_message(self,
+            field_name, field):
+        """
+        Overwrites the field error message(set by validators) with custom field error message.
+
+        If the field has an `error_messages` property set on it
+        and the field has encountered an error while running the validators;
+        then the filed error message will be overwritten by the custom field error message.
+        """
+        if self._errors.get(field_name) and field.error_dict:
+            self._errors[field_name] = field.error_dict
 
     @property
     def object(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 --index-url=https://pypi.python.org/simple/
+
 # Actual Dependencies
 -e .
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--index-url=https://pypi.python.org/simple/
 # Actual Dependencies
 -e .
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Internet :: WWW/HTTP',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pyserializer',
-    version='0.7.0',
+    version='0.8.0',
     description='Simple python serialization library.',
     author='LocalMed',
     author_email='ecordell@localmed.com, pete@localmed.com, joeljames1985@gmail.com',  # NOQA

--- a/tests/functional_tests/pyserializer/custom_error_message_tests.py
+++ b/tests/functional_tests/pyserializer/custom_error_message_tests.py
@@ -1,0 +1,46 @@
+from nose.tools import *  # flake8: noqa
+from mock import *  # flake8: noqa
+
+from collections import OrderedDict
+
+from pyserializer import fields
+from pyserializer.serializers import Serializer
+
+
+class TestSetsCustomErrorMessageWhenErrorMessagesArgIsSetWhenDeclaringField:
+
+    def setup(self):
+        class UserDeserializer(Serializer):
+            age = fields.IntegerField()
+            dob = fields.DateField(
+                error_messages={'invalid': 'Custom error message.'}
+            )
+
+            def __repr__(self):
+                return '<User(%r)>' % (self.dob)
+
+        self.UserDeserializer = UserDeserializer
+
+    def test_sets_custom_error_message(self):
+        input_data = {
+            'age': 'invalid_age',
+            'dob': 'invalid_date'
+        }
+        deserializer = self.UserDeserializer(data_dict=input_data)
+        assert_false(deserializer.is_valid())
+        assert_equal(
+            deserializer.errors['age'],
+            [OrderedDict([
+                ('type_name', 'IntegerValidator'),
+                ('type_label', 'integer'),
+                ('message', 'Ensure the value invalid_age is of type integer.')
+            ])]
+        )
+        assert_equal(
+            deserializer.errors['dob'],
+            [OrderedDict([
+                ('type_name', 'DateField'),
+                ('type_label', 'date'),
+                ('message', 'Custom error message.')
+            ])]
+        )

--- a/tests/functional_tests/pyserializer/custom_error_message_tests.py
+++ b/tests/functional_tests/pyserializer/custom_error_message_tests.py
@@ -5,42 +5,75 @@ from collections import OrderedDict
 
 from pyserializer import fields
 from pyserializer.serializers import Serializer
+from pyserializer import validators
 
 
 class TestSetsCustomErrorMessageWhenErrorMessagesArgIsSetWhenDeclaringField:
 
     def setup(self):
         class UserDeserializer(Serializer):
-            age = fields.IntegerField()
+            name = fields.CharField(
+                validators=[
+                    validators.MaxLengthValidator(3)
+                ]
+            )
+            age = fields.IntegerField(
+                validators=[
+                    validators.MinValueValidator(18),
+                    validators.MaxValueValidator(30)
+                ],
+                error_messages={
+                  'min_value': 'You must be at least 18 years old to signup',
+                  'max_value': 'You are too old.'
+                }
+            )
             dob = fields.DateField(
                 error_messages={'invalid': 'Custom error message.'}
             )
 
             def __repr__(self):
-                return '<User(%r)>' % (self.dob)
+                return '<User(%r)>' % (self.name)
 
         self.UserDeserializer = UserDeserializer
 
+
     def test_sets_custom_error_message(self):
         input_data = {
-            'age': 'invalid_age',
+            'name': 'John Smith',
+            'age': 50,
             'dob': 'invalid_date'
         }
         deserializer = self.UserDeserializer(data_dict=input_data)
         assert_false(deserializer.is_valid())
         assert_equal(
-            deserializer.errors['age'],
+            deserializer.errors['name'],
             [OrderedDict([
-                ('type_name', 'IntegerValidator'),
-                ('type_label', 'integer'),
-                ('message', 'Ensure the value invalid_age is of type integer.')
+                ('type_name', 'MaxLengthValidator'),
+                ('type_label', 'max_length'),
+                ('message', 'Ensure the value has atmost 3 characters(it has 10 characters).')
             ])]
+        )
+        assert_equal(
+            deserializer.errors['age'][0]['type_name'],
+            'IntegerField'
+        )
+        assert_equal(
+            deserializer.errors['age'][0]['type_label'],
+            'integer'
+        )
+        assert_equal(
+            deserializer.errors['age'][0]['max_value'],
+            'You are too old.'
+        )
+        assert_equal(
+            deserializer.errors['age'][0]['min_value'],
+            'You must be at least 18 years old to signup'
         )
         assert_equal(
             deserializer.errors['dob'],
             [OrderedDict([
                 ('type_name', 'DateField'),
                 ('type_label', 'date'),
-                ('message', 'Custom error message.')
+                ('invalid', 'Custom error message.')
             ])]
         )

--- a/tests/functional_tests/pyserializer/fields_tests.py
+++ b/tests/functional_tests/pyserializer/fields_tests.py
@@ -42,11 +42,11 @@ class TestSetsCustomErrorMessageWhenErrorMessagesArgIsSetWhenDeclaringField:
         )
         assert_equal(
             deserializer.errors['dob'],
-            OrderedDict([
+            [OrderedDict([
                 ('type_name', 'DateField'),
                 ('type_label', 'date'),
                 ('message', 'Custom error message.')
-            ])
+            ])]
         )
 
 

--- a/tests/functional_tests/pyserializer/fields_tests.py
+++ b/tests/functional_tests/pyserializer/fields_tests.py
@@ -11,6 +11,45 @@ from pyserializer import fields
 from pyserializer.serializers import Serializer
 
 
+class TestSetsCustomErrorMessageWhenErrorMessagesArgIsSetWhenDeclaringField:
+
+    def setup(self):
+        class UserDeserializer(Serializer):
+            age = fields.IntegerField()
+            dob = fields.DateField(
+                error_messages={'invalid': 'Custom error message.'}
+            )
+
+            def __repr__(self):
+                return '<User(%r)>' % (self.dob)
+
+        self.UserDeserializer = UserDeserializer
+
+    def test_sets_custom_error_message(self):
+        input_data = {
+            'age': 'invalid_age',
+            'dob': 'invalid_date'
+        }
+        deserializer = self.UserDeserializer(data_dict=input_data)
+        assert_false(deserializer.is_valid())
+        assert_equal(
+            deserializer.errors['age'],
+            [OrderedDict([
+                ('type_name', 'IntegerValidator'),
+                ('type_label', 'integer'),
+                ('message', 'Ensure the value invalid_age is of type integer.')
+            ])]
+        )
+        assert_equal(
+            deserializer.errors['dob'],
+            OrderedDict([
+                ('type_name', 'DateField'),
+                ('type_label', 'date'),
+                ('message', 'Custom error message.')
+            ])
+        )
+
+
 class TestDateFieldDeserializer:
 
     def setup(self):

--- a/tests/functional_tests/pyserializer/fields_tests.py
+++ b/tests/functional_tests/pyserializer/fields_tests.py
@@ -11,45 +11,6 @@ from pyserializer import fields
 from pyserializer.serializers import Serializer
 
 
-class TestSetsCustomErrorMessageWhenErrorMessagesArgIsSetWhenDeclaringField:
-
-    def setup(self):
-        class UserDeserializer(Serializer):
-            age = fields.IntegerField()
-            dob = fields.DateField(
-                error_messages={'invalid': 'Custom error message.'}
-            )
-
-            def __repr__(self):
-                return '<User(%r)>' % (self.dob)
-
-        self.UserDeserializer = UserDeserializer
-
-    def test_sets_custom_error_message(self):
-        input_data = {
-            'age': 'invalid_age',
-            'dob': 'invalid_date'
-        }
-        deserializer = self.UserDeserializer(data_dict=input_data)
-        assert_false(deserializer.is_valid())
-        assert_equal(
-            deserializer.errors['age'],
-            [OrderedDict([
-                ('type_name', 'IntegerValidator'),
-                ('type_label', 'integer'),
-                ('message', 'Ensure the value invalid_age is of type integer.')
-            ])]
-        )
-        assert_equal(
-            deserializer.errors['dob'],
-            [OrderedDict([
-                ('type_name', 'DateField'),
-                ('type_label', 'date'),
-                ('message', 'Custom error message.')
-            ])]
-        )
-
-
 class TestDateFieldDeserializer:
 
     def setup(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34
+envlist = py27, py33, py34, py35
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
This PR adds the ability to add custom error messages on serializer fields. Click  https://github.com/localmed/pyserializer/issues/12 for more info on the issue.

@petebrowne @reneric whenever you get a chance can you guys take a look at this PR?
And if every thing looks good can you guys push up a new release after merging it to `localmed/pyserializer` master branch. I have already bumped the version number. This release should be `0.8.0`. You will also have to build a new version of docs which gets published to [Read the Docs](http://pyserializer.readthedocs.io/en/latest/) as I have made changes to the docs. 