### PR TITLE
Relax six dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
+  - "3.6"
 install:
   - "pip install -e ."
   - "pip install -r requirements.txt"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     install_requires=[
-        'six==1.10.0'
+        'six>=1.10.0'
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
When using `pipenv` it's pretty hard to not run into conflicts with exact version requirements.